### PR TITLE
Add TinyTools to Others (free browser-based marketing/SEO utilities)

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ Want to contribute to grow/improve this? PRs welcome!
 - [Scaling DevTools](https://podcast.bitreach.io/)
 - [Marketing Jobs in OSS Startups](https://www.ossjobs.dev/?category=Marketing)
 - [Marketing Jobs in Dev Tooling Companies](https://devtooljobs.com/marketing)
+- [TinyTools](https://tinytools-smoky.vercel.app/) - Free browser-based utilities useful for dev marketers: SEO meta tag generator, OG image generator with live preview, favicon generator, color palette generator, AI Robots.txt generator (GPTBot/ClaudeBot/PerplexityBot), and AI Content Disclosure generator. No signup, no tracking, fully client-side, open source.
 
 
 # Influencers and Educators


### PR DESCRIPTION
Hi Ronak, thanks for maintaining this list!

Adding [TinyTools](https://tinytools-smoky.vercel.app/) under the "Others" section. It's a free, open-source collection of single-purpose browser-based utilities that dev marketers commonly need — SEO meta tags, OG image generator (with live preview), favicon generator, color palette generator, plus newer entries like an AI Robots.txt generator (GPTBot/ClaudeBot/PerplexityBot) and AI Content Disclosure generator for EU AI Act Article 50 compliance.

Everything runs client-side, no signup, no tracking. Felt most at home in the "Others" miscellany — happy to move it elsewhere (e.g. tucked closer to the GTM/content tooling area) or to tighten the wording if you'd prefer.